### PR TITLE
Use semantic-release to automate npm publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,25 @@
+name: Release
+on:
+  push:
+    branches:
+      - master
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: "lts/*"
+      - name: Install dependencies
+        run: npm ci
+      - name: Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npx semantic-release

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,13 @@
+{
+  "branches": ["main"],
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    "@semantic-release/changelog",
+    "@semantic-release/npm",
+    "@semantic-release/github",
+    "@semantic-release/git"
+  ],
+  "preset": "angular",
+  "dryRun": true
+}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "main": "transform.js",
   "scripts": {
-    "test": "npx ava"
+    "test": "npx ava",
+    "semantic-release": "semantic-release"
   },
   "keywords": [],
   "contributors": [
@@ -13,7 +14,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/tweetback/tweetback-canonical.git"
+    "url": "https://github.com/tweetback/tweetback-canonical.git"
   },
   "homepage": "https://github.com/tweetback/tweetback-canonical#readme",
   "publishConfig": {
@@ -21,6 +22,9 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "ava": "^5.1.0"
+    "@semantic-release/changelog": "^6.0.2",
+    "@semantic-release/git": "^10.0.1",
+    "ava": "^5.1.0",
+    "semantic-release": "^19.0.5"
   }
 }


### PR DESCRIPTION
Use https://semantic-release.gitbook.io/semantic-release/ to automate publication of a package release on npm when a PR is merged into `main` branch.