### PR TITLE
mapping: Add mapping for Phil Hawksworth's archive

### DIFF
--- a/mapping.js
+++ b/mapping.js
@@ -26,4 +26,5 @@ export const mapping = {
 	"MarcoZehe": "https://twitter.marcos-leben.de",
 	"MarcoInEnglish": "https://twitter.marcozehe.de",
 	"jefflembeck": "https://twitter.jefflembeck.com",
+	"philhawksworth": "https://www.hawksworx.com/note/tw/",
 };


### PR DESCRIPTION
My archive resides here:

https://www.hawksworx.com/notes/

With post permalink URLs mapping to tweet URLs in the form:

`https://www.hawksworx.com/note/tw/{ID}` == `https://twitter.com/philhawksworth/status/{ID}`

Dropping the ID from the URL results in a redirect to the paginated index of the archive:
 
`https://www.hawksworx.com/note/tw/` -> `https://www.hawksworx.com/notes/`