### PR TITLE
mapping: Add @404boyfriend twitter archive

### DIFF
--- a/mapping.js
+++ b/mapping.js
@@ -26,4 +26,5 @@ export const mapping = {
 	"MarcoZehe": "https://twitter.marcos-leben.de",
 	"MarcoInEnglish": "https://twitter.marcozehe.de",
 	"jefflembeck": "https://twitter.jefflembeck.com",
+	"404boyfriend": "https://tweets.henry.codes"
 };


### PR DESCRIPTION
One question I had was: if I changed my username semi-recently, should I add that account name to mapping as well? Probably not I'd guess, cause most archives will have come from after the name change, but.